### PR TITLE
fix grayscale mode

### DIFF
--- a/app/src/main/java/nethical/digipaws/utils/MonochromeTools.kt
+++ b/app/src/main/java/nethical/digipaws/utils/MonochromeTools.kt
@@ -21,7 +21,7 @@ class GrayscaleControl {
      */
     fun enableGrayscale() {
         ShizukuRunner.executeCommand(
-            "settings put secure accessibility_display_daltonizer 1 && " +
+            "settings put secure accessibility_display_daltonizer 0 && " +
                     "settings put secure accessibility_display_daltonizer_enabled 1",
             commandListener
         )
@@ -32,8 +32,7 @@ class GrayscaleControl {
      */
     fun disableGrayscale() {
         ShizukuRunner.executeCommand(
-            "settings put secure accessibility_display_daltonizer 0 && " +
-                    "settings put secure accessibility_display_daltonizer_enabled 0",
+            "settings put secure accessibility_display_daltonizer_enabled 0",
             commandListener
         )
     }
@@ -44,10 +43,9 @@ class GrayscaleControl {
     fun toggleGrayscale() {
         ShizukuRunner.executeCommand(
             "if [ $(settings get secure accessibility_display_daltonizer_enabled) = \"1\" ]; then " +
-                    "settings put secure accessibility_display_daltonizer 0 && " +
                     "settings put secure accessibility_display_daltonizer_enabled 0; " +
                     "else " +
-                    "settings put secure accessibility_display_daltonizer 1 && " +
+                    "settings put secure accessibility_display_daltonizer 0 && " +
                     "settings put secure accessibility_display_daltonizer_enabled 1; " +
                     "fi",
             commandListener


### PR DESCRIPTION
The grayscale mode did not work correctly and instead turned on the deuteronomaly filter. To enable the grayscale mode, `accessibility_display_daltonizer` has to be set to `0` instead of `1`. When disabling it, setting `_enabled` without the mode is also sufficient.

Link: https://android.googlesource.com/platform/frameworks/base/+/f5d84802d18d50663ee20d2989ca0b7f3b7004e3/core/java/android/provider/Settings.java#9207
Fixes #80