### PR TITLE
Remove crashing line

### DIFF
--- a/app/src/main/java/nethical/digipaws/services/AppBlockerService.kt
+++ b/app/src/main/java/nethical/digipaws/services/AppBlockerService.kt
@@ -116,7 +116,6 @@ class AppBlockerService : BaseBlockingService() {
     }
 
     override fun onInterrupt() {
-        TODO("Not yet implemented")
     }
 
     @SuppressLint("UnspecifiedRegisterReceiverFlag")


### PR DESCRIPTION
- Sometimes the system triggers the onInterrupt call so the app blocker service ends disabled due to the crash,  until the user manually enables the service again.

- Remove the "TODO" line to avoid app crashing in certain circunstances, resulting in the shutdown of the app blocking service.