### PR TITLE
cheat hours/time selector bug fixes

### DIFF
--- a/app/src/main/java/nethical/digipaws/blockers/AppBlocker.kt
+++ b/app/src/main/java/nethical/digipaws/blockers/AppBlocker.kt
@@ -80,9 +80,16 @@ class AppBlocker:BaseBlocker() {
             if ((startMinutes <= endMinutes && currentMinutes in startMinutes until endMinutes) ||
                 (startMinutes > endMinutes && (currentMinutes >= startMinutes || currentMinutes < endMinutes))
             ) {
+                var dayOffsetMinutes = 0
+
+                // if cheat hours cross midnight and it is still the first day treat the end time as tomorrow
+                if (startMinutes > endMinutes && currentMinutes > endMinutes) {
+                    dayOffsetMinutes = 1440
+                }
 
                 // Convert endMinutes to uptimeMillis
-                val diffMinutes = endMinutes - currentMinutes
+                val diffMinutes = endMinutes + dayOffsetMinutes - currentMinutes
+
                 Log.d("AppBlocker", "$packageName cheat-hour ends after $diffMinutes minutes")
                 val endTimeMillis = uptimeNow + (diffMinutes * 60 * 1000)
 

--- a/app/src/main/java/nethical/digipaws/ui/activity/TimedActionActivity.kt
+++ b/app/src/main/java/nethical/digipaws/ui/activity/TimedActionActivity.kt
@@ -91,13 +91,18 @@ class TimedActionActivity : AppCompatActivity() {
 
         dialogAddToTimedActionBinding = DialogAddTimedActionBinding.inflate(layoutInflater)
 
-        var startTimeInMins: Int = TimeRangePicker.Time(6, 30).totalMinutes
-        var endTimeInMins: Int = TimeRangePicker.Time(22, 0).totalMinutes
+        val startTime = TimeRangePicker.Time(6, 30)
+        val endTime = TimeRangePicker.Time(22, 0)
+
+        var startTimeInMins: Int = startTime.totalMinutes
+        var endTimeInMins: Int = endTime.totalMinutes
 
         dialogAddToTimedActionBinding.picker.hourFormat = TimeRangePicker.HourFormat.FORMAT_24
 
         dialogAddToTimedActionBinding.picker.startTimeMinutes = startTimeInMins
         dialogAddToTimedActionBinding.picker.endTimeMinutes = endTimeInMins
+        dialogAddToTimedActionBinding.fromTime.text = startTime.toString()
+        dialogAddToTimedActionBinding.endTime.text = endTime.toString()
 
         dialogAddToTimedActionBinding.picker.setOnTouchListener { v, event ->
             // Disable ScrollView's touch interception when interacting with the picker

--- a/app/src/main/java/nethical/digipaws/ui/activity/TimedActionActivity.kt
+++ b/app/src/main/java/nethical/digipaws/ui/activity/TimedActionActivity.kt
@@ -20,6 +20,7 @@ import nethical.digipaws.R
 import nethical.digipaws.databinding.ActivityAddTimedActionActivityBinding
 import nethical.digipaws.databinding.CheatHourItemBinding
 import nethical.digipaws.databinding.DialogAddTimedActionBinding
+import nethical.digipaws.services.AppBlockerService
 import nethical.digipaws.utils.SavedPreferencesLoader
 import nethical.digipaws.utils.TimeTools
 import nl.joery.timerangepicker.TimeRangePicker
@@ -253,11 +254,15 @@ class TimedActionActivity : AppCompatActivity() {
 
     private fun saveList() {
         when (selectedMode) {
-            MODE_APP_BLOCKER_CHEAT_HOURS -> savedPreferencesLoader.saveAppBlockerCheatHoursList(
-                timedActionList
-            )
+            MODE_APP_BLOCKER_CHEAT_HOURS -> {
+                savedPreferencesLoader.saveAppBlockerCheatHoursList(timedActionList)
+                sendBroadcast(Intent(AppBlockerService.INTENT_ACTION_REFRESH_APP_BLOCKER))
+            }
 
-            MODE_AUTO_FOCUS -> savedPreferencesLoader.saveAutoFocusHoursList(timedActionList)
+            MODE_AUTO_FOCUS -> {
+                savedPreferencesLoader.saveAutoFocusHoursList(timedActionList)
+                sendBroadcast(Intent(AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE))
+            }
         }
     }
 

--- a/app/src/main/java/nethical/digipaws/ui/activity/TimedActionActivity.kt
+++ b/app/src/main/java/nethical/digipaws/ui/activity/TimedActionActivity.kt
@@ -91,12 +91,13 @@ class TimedActionActivity : AppCompatActivity() {
 
         dialogAddToTimedActionBinding = DialogAddTimedActionBinding.inflate(layoutInflater)
 
-        dialogAddToTimedActionBinding.picker.startTime = TimeRangePicker.Time(6, 30)
-        dialogAddToTimedActionBinding.picker.endTime = TimeRangePicker.Time(22, 0)
+        var startTimeInMins: Int = TimeRangePicker.Time(6, 30).totalMinutes
+        var endTimeInMins: Int = TimeRangePicker.Time(22, 0).totalMinutes
 
         dialogAddToTimedActionBinding.picker.hourFormat = TimeRangePicker.HourFormat.FORMAT_24
-        var endTimeInMins: Int? = dialogAddToTimedActionBinding.picker.endTimeMinutes
-        var startTimeInMins: Int? = dialogAddToTimedActionBinding.picker.startTimeMinutes
+
+        dialogAddToTimedActionBinding.picker.startTimeMinutes = startTimeInMins
+        dialogAddToTimedActionBinding.picker.endTimeMinutes = endTimeInMins
 
         dialogAddToTimedActionBinding.picker.setOnTouchListener { v, event ->
             // Disable ScrollView's touch interception when interacting with the picker

--- a/app/src/main/java/nethical/digipaws/ui/dialogs/TweakViewBlockerCheatHours.kt
+++ b/app/src/main/java/nethical/digipaws/ui/dialogs/TweakViewBlockerCheatHours.kt
@@ -43,6 +43,8 @@ class TweakViewBlockerCheatHours(savedPreferencesLoader: SavedPreferencesLoader)
         if (savedStartTimeInMinutes != -1 || savedEndTimeInMinutes != -1) {
             dialogAddToCheatHoursBinding.picker.startTimeMinutes = savedStartTimeInMinutes
             dialogAddToCheatHoursBinding.picker.endTimeMinutes = savedEndTimeInMinutes
+            dialogAddToCheatHoursBinding.fromTime.text = TimeRangePicker.Time(savedStartTimeInMinutes).toString()
+            dialogAddToCheatHoursBinding.endTime.text = TimeRangePicker.Time(savedEndTimeInMinutes).toString()
             startTimeInMins = savedStartTimeInMinutes
             endTimeInMins = savedEndTimeInMinutes
         } else {


### PR DESCRIPTION
various fixes for bugs with the app blockers cheat hours and the time selector
- fixed the time selectors initially displaying incorrect values (fixes #144)
- fixed an issue where the app blocker was not refreshed when cheat hours are changed
- fixed an issue where cheat hours would not work if the start and end time were on different days (end time was after midnight)

#141 might be fixed by this but i'm not 100% sure
the commit messages contain more info on what caused the bugs