### PR TITLE
feat: Support Graphene OS system browser Vanadium

### DIFF
--- a/app/src/main/java/nethical/digipaws/blockers/KeywordBlocker.kt
+++ b/app/src/main/java/nethical/digipaws/blockers/KeywordBlocker.kt
@@ -19,6 +19,10 @@ class KeywordBlocker(val service: AccessibilityService) : BaseBlocker() {
                 displayUrlBarId = "url_bar",
                 browserSugggestionBoxId = "omnibox_suggestions_dropdown"
             ),
+            "app.vanadium.browser" to BrowserUrlBarInfo(
+                displayUrlBarId = "url_bar",
+                browserSugggestionBoxId = "omnibox_suggestions_dropdown"
+            ),
             "com.brave.browser" to BrowserUrlBarInfo(
                 displayUrlBarId = "url_bar",
                 browserSugggestionBoxId = "omnibox_suggestions_dropdown"


### PR DESCRIPTION
Vanadium is the system browser of Graphene OS. This PR adds support for it to Digipaws