### PR TITLE
fix: KeywordBlocker handle null values gracefully

### DIFF
--- a/app/src/main/java/nethical/digipaws/blockers/KeywordBlocker.kt
+++ b/app/src/main/java/nethical/digipaws/blockers/KeywordBlocker.kt
@@ -110,7 +110,10 @@ class KeywordBlocker(val service: AccessibilityService) : BaseBlocker() {
 
             try {
                 recursionResultNodes.forEach { node ->
-                    val word = containsBlockedKeyword(node.text.toString())
+                    // Guard against null text
+                    val nodeText = node.text?.toString() ?: ""
+                    if (nodeText.isEmpty()) return@forEach
+                    val word = containsBlockedKeyword(nodeText)
                     if (word != null) {
                         detectedAdultKeyword = word
                         return@forEach
@@ -135,10 +138,10 @@ class KeywordBlocker(val service: AccessibilityService) : BaseBlocker() {
 
 
         if (detectedAdultKeyword == null) {
-
-            detectedAdultKeyword = searchKeywordsInWebViewTitle(rootNode) ?: containsBlockedKeyword(
-                displayUrlTextNode?.text.toString()
-            ) ?: return KeywordBlockerResult()
+            // Safely handle possible nulls from searchKeywordsInWebViewTitle and displayUrlTextNode.text
+            val webViewKeyword = searchKeywordsInWebViewTitle(rootNode)
+            val displayText = displayUrlTextNode?.text?.toString() ?: ""
+            detectedAdultKeyword = webViewKeyword ?: (if (displayText.isNotEmpty()) containsBlockedKeyword(displayText) else null) ?: return KeywordBlockerResult()
 
         }
         performSmallUpwardScroll()
@@ -187,7 +190,11 @@ class KeywordBlocker(val service: AccessibilityService) : BaseBlocker() {
 
         Log.d("Keyword Blocker", "Webview title $resultWord")
 
-        return containsBlockedKeyword(resultWord.toString())
+        // Guard against null text on webview
+        val titleText = resultWord?.toString() ?: ""
+        if (titleText.isEmpty()) return null
+
+        return containsBlockedKeyword(titleText)
 
     }
 


### PR DESCRIPTION
I noticed that sometimes but infrequently the KeywordBlocker crashes because of a NullPointerException. I don't know what exactly was causing the issue, but this fix seems to work.

I just added some null checks and I had no crashes since.

This should fix:
- #177 (maybe)
- #169 
- #136