### PR TITLE
WIP: Added NFC lock feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,9 @@
         android:name="android.permission.PACKAGE_USAGE_STATS"
         tools:ignore="ProtectedPermissions" />
 <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+    <uses-permission android:name="android.permission.NFC"/>
+
+    <uses-feature android:name="android.hardware.nfc" android:required="false"/>
     <application
         android:name=".Digipaws"
         android:allowBackup="true"
@@ -54,7 +57,8 @@
             android:exported="false" />
         <activity
             android:name=".ui.activity.MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -66,6 +70,18 @@
             android:name=".ui.activity.LauncherActivity"
             android:exported="true"
             android:launchMode="singleTask" />
+        <activity
+            android:name=".ui.activity.NfcTagActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:excludeFromRecents="true"
+            android:theme="@style/Theme.Digipaws.TransparentDialog">
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:scheme="digipaws" android:host="nfclock"/>
+            </intent-filter>
+        </activity>
 
         <service
             android:name=".services.ViewBlockerService"

--- a/app/src/main/java/nethical/digipaws/Constants.kt
+++ b/app/src/main/java/nethical/digipaws/Constants.kt
@@ -19,5 +19,9 @@ class Constants {
         const val GRAYSCALE_MODE_ONLY_SELECTED = 2 // apply to only selected
         const val GRAYSCALE_MODE_ALL_EXCEPT_SELECTED = 3 // apply to all except selected
         const val GRAYSCALE_MODE_OFF = 4 // turned off
+
+        // available types for NFC lock mode
+        const val NFC_LOCK_MODE_BLOCK_SELECTED = 1
+        const val NFC_LOCK_MODE_BLOCK_ALL_EX_SELECTED = 2
     }
 }

--- a/app/src/main/java/nethical/digipaws/blockers/NfcLockBlocker.kt
+++ b/app/src/main/java/nethical/digipaws/blockers/NfcLockBlocker.kt
@@ -1,0 +1,87 @@
+package nethical.digipaws.blockers
+
+import nethical.digipaws.Constants
+
+class NfcLockBlocker : BaseBlocker() {
+
+    var nfcLockModeData = NfcLockModeData()
+    var selectedApps: HashSet<String> = hashSetOf()
+
+    /**
+     * Check if app needs to be blocked for reasons related to NFC lock mode
+     *
+     * @param packageName
+     * @return NfcLockResult
+     */
+    fun doesAppNeedToBeBlocked(packageName: String): NfcLockResult {
+        if (!nfcLockModeData.isEnabled) {
+            return NfcLockResult(isBlocked = false)
+        }
+
+        // Check failsafe timer - auto-unlock if expired
+        if (nfcLockModeData.autoUnlockAt != -1L &&
+            System.currentTimeMillis() > nfcLockModeData.autoUnlockAt
+        ) {
+            nfcLockModeData.isEnabled = false
+            return NfcLockResult(isBlocked = false, isRequestingToUpdateSPData = true)
+        }
+
+        // Check if app should be blocked based on mode type
+        when (nfcLockModeData.modeType) {
+            Constants.NFC_LOCK_MODE_BLOCK_SELECTED -> {
+                if (selectedApps.contains(packageName)) {
+                    return NfcLockResult(
+                        isBlocked = true,
+                        autoUnlockAt = nfcLockModeData.autoUnlockAt
+                    )
+                }
+            }
+
+            Constants.NFC_LOCK_MODE_BLOCK_ALL_EX_SELECTED -> {
+                if (!selectedApps.contains(packageName)) {
+                    return NfcLockResult(
+                        isBlocked = true,
+                        autoUnlockAt = nfcLockModeData.autoUnlockAt
+                    )
+                }
+            }
+        }
+        return NfcLockResult(isBlocked = false)
+    }
+
+    /**
+     * Stores information related to NFC lock mode
+     *
+     * @property isEnabled Whether NFC lock mode is currently active
+     * @property modeType Can either be [Constants.NFC_LOCK_MODE_BLOCK_SELECTED] or [Constants.NFC_LOCK_MODE_BLOCK_ALL_EX_SELECTED]
+     * @property enabledAt Timestamp when NFC lock mode was enabled, -1 if not enabled
+     * @property autoUnlockAt Timestamp when failsafe auto-unlock should occur, -1 if failsafe disabled
+     * @property failsafeHours Number of hours for failsafe timer (0 = disabled, max 168)
+     * @property emergencyPassword Password for emergency unlock
+     * @property requireTagValidation Whether to validate tag UID before toggling
+     * @property registeredTagIds Set of registered NFC tag UIDs for validation
+     */
+    data class NfcLockModeData(
+        var isEnabled: Boolean = false,
+        val modeType: Int = Constants.NFC_LOCK_MODE_BLOCK_SELECTED,
+        val enabledAt: Long = -1,
+        val autoUnlockAt: Long = -1,
+        val failsafeHours: Int = 24,
+        val emergencyPassword: String = "",
+        val requireTagValidation: Boolean = false,
+        val registeredTagIds: HashSet<String> = hashSetOf()
+    )
+
+    /**
+     * NFC lock mode blocker check result
+     *
+     * @property isBlocked Whether the app should be blocked
+     * @property autoUnlockAt Timestamp when auto-unlock will occur, -1 if failsafe disabled
+     * @property isRequestingToUpdateSPData Returns true if nfcLockModeData needs to be saved because lock mode has ended
+     */
+    data class NfcLockResult(
+        val isBlocked: Boolean,
+        val autoUnlockAt: Long = -1,
+        val isRequestingToUpdateSPData: Boolean = false
+    )
+}

--- a/app/src/main/java/nethical/digipaws/services/AppBlockerService.kt
+++ b/app/src/main/java/nethical/digipaws/services/AppBlockerService.kt
@@ -15,6 +15,7 @@ import android.widget.Toast
 import nethical.digipaws.Constants
 import nethical.digipaws.blockers.AppBlocker
 import nethical.digipaws.blockers.FocusModeBlocker
+import nethical.digipaws.blockers.NfcLockBlocker
 import nethical.digipaws.ui.activity.MainActivity
 import nethical.digipaws.ui.activity.WarningActivity
 import nethical.digipaws.utils.NotificationTimerManager
@@ -42,14 +43,19 @@ class AppBlockerService : BaseBlockingService() {
         /**
          * Refreshes information related to focus mode.
          */
-
         const val INTENT_ACTION_REFRESH_FOCUS_MODE = "nethical.digipaws.refresh.focus_mode"
+
+        /**
+         * Refreshes information related to NFC lock mode.
+         */
+        const val INTENT_ACTION_REFRESH_NFC_LOCK_MODE = "nethical.digipaws.refresh.nfc_lock_mode"
     }
 
     private var appBlockerWarning = MainActivity.WarningData()
     private lateinit var appBlocker : AppBlocker
 
     private val focusModeBlocker = FocusModeBlocker()
+    private val nfcLockBlocker = NfcLockBlocker()
 
     // responsible to trigger a recheck for what app user is currently using even when no event is received. Used in putting the usage recheck logic into
     // cooldown for an app and later when the cooldown duration is over, trigger a recheck
@@ -72,6 +78,16 @@ class AppBlockerService : BaseBlockingService() {
 
         lastPackage = packageName
         Log.d("AppBlockerService", "Switched to app $packageName")
+
+        // Check NFC lock mode first (highest priority)
+        val nfcLockResult = nfcLockBlocker.doesAppNeedToBeBlocked(packageName)
+        if (nfcLockResult.isBlocked) {
+            handleNfcLockBlockerResult(nfcLockResult)
+            return
+        }
+        if (nfcLockResult.isRequestingToUpdateSPData) {
+            savedPreferencesLoader.saveNfcLockModeData(nfcLockBlocker.nfcLockModeData)
+        }
 
         val focusModeResult = focusModeBlocker.doesAppNeedToBeBlocked(packageName)
         if (focusModeResult.isBlocked) {
@@ -132,6 +148,18 @@ class AppBlockerService : BaseBlockingService() {
         Toast.makeText(this, "This app is currently under focus mode", Toast.LENGTH_LONG).show()
     }
 
+    private fun handleNfcLockBlockerResult(result: NfcLockBlocker.NfcLockResult) {
+        if (result.isRequestingToUpdateSPData) {
+            savedPreferencesLoader.saveNfcLockModeData(nfcLockBlocker.nfcLockModeData)
+        }
+
+        if (!result.isBlocked) return
+
+        pressHome()
+        lastPackage = ""
+        Toast.makeText(this, "This app is locked by NFC Lock Mode", Toast.LENGTH_LONG).show()
+    }
+
     override fun onInterrupt() {
     }
 
@@ -140,11 +168,13 @@ class AppBlockerService : BaseBlockingService() {
         super.onServiceConnected()
         setupAppBlocker()
         setupFocusMode()
+        setupNfcLockMode()
         notificationManager = NotificationTimerManager(this)
         val filter = IntentFilter().apply {
             addAction(INTENT_ACTION_REFRESH_FOCUS_MODE)
             addAction(INTENT_ACTION_REFRESH_APP_BLOCKER)
             addAction(INTENT_ACTION_REFRESH_APP_BLOCKER_COOLDOWN)
+            addAction(INTENT_ACTION_REFRESH_NFC_LOCK_MODE)
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             registerReceiver(refreshReceiver, filter, RECEIVER_EXPORTED)
@@ -160,6 +190,7 @@ class AppBlockerService : BaseBlockingService() {
             when (intent.action) {
                 INTENT_ACTION_REFRESH_FOCUS_MODE -> setupFocusMode()
                 INTENT_ACTION_REFRESH_APP_BLOCKER -> setupAppBlocker()
+                INTENT_ACTION_REFRESH_NFC_LOCK_MODE -> setupNfcLockMode()
                 INTENT_ACTION_REFRESH_APP_BLOCKER_COOLDOWN -> {
                     val interval =
                         intent.getIntExtra("selected_time", appBlockerWarning.timeInterval)
@@ -234,6 +265,22 @@ class AppBlockerService : BaseBlockingService() {
         focusModeData.selectedApps = selectedFocusModeApps
         focusModeBlocker.focusModeData = focusModeData
 
+    }
+
+    private fun setupNfcLockMode() {
+        val selectedNfcLockApps = savedPreferencesLoader.getNfcLockSelectedApps().toHashSet()
+        val nfcLockModeData = savedPreferencesLoader.getNfcLockModeData()
+
+        // As all apps will get blocked except the selected ones, add essential packages that need not be blocked
+        if (nfcLockModeData.modeType == Constants.NFC_LOCK_MODE_BLOCK_ALL_EX_SELECTED) {
+            selectedNfcLockApps.add("com.android.systemui")
+            getDefaultLauncherPackageName(packageManager)?.let { selectedNfcLockApps.add(it) }
+            getCurrentKeyboardPackageName(this)?.let { selectedNfcLockApps.add(it) }
+        }
+
+        nfcLockBlocker.selectedApps = selectedNfcLockApps
+        nfcLockBlocker.nfcLockModeData = nfcLockModeData
+        Log.d("AppBlockerService", "NFC Lock Mode setup: enabled=${nfcLockModeData.isEnabled}")
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/nethical/digipaws/ui/activity/MainActivity.kt
+++ b/app/src/main/java/nethical/digipaws/ui/activity/MainActivity.kt
@@ -12,6 +12,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.nfc.NfcAdapter
+import android.nfc.Tag
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -50,6 +52,9 @@ import nethical.digipaws.services.GeneralFeaturesService
 import nethical.digipaws.services.KeywordBlockerService
 import nethical.digipaws.services.UsageTrackingService
 import nethical.digipaws.services.ViewBlockerService
+import nethical.digipaws.ui.dialogs.ConfigureNfcLockDialog
+import nethical.digipaws.ui.dialogs.NfcEmergencyUnlockDialog
+import nethical.digipaws.ui.dialogs.NfcWriteTagDialog
 import nethical.digipaws.ui.dialogs.StartFocusMode
 import nethical.digipaws.ui.dialogs.TweakAppBlockerWarning
 import nethical.digipaws.ui.dialogs.TweakGrayScaleMode
@@ -91,7 +96,13 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var addAutoFocusHoursActivity: ActivityResultLauncher<Intent>
 
+    private lateinit var selectNfcLockAppsLauncher: ActivityResultLauncher<Intent>
+
     private lateinit var directoryPicker: ActivityResultLauncher<Intent>
+
+    private var nfcAdapter: NfcAdapter? = null
+    private var activeNfcWriteDialog: NfcWriteTagDialog? = null
+    private var activeNfcConfigDialog: ConfigureNfcLockDialog? = null
 
 
     private val savedPreferencesLoader = SavedPreferencesLoader(this)
@@ -145,6 +156,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         options = ActivityOptionsCompat.makeCustomAnimation(this, R.anim.fade_in, R.anim.fade_out)
+        nfcAdapter = NfcAdapter.getDefaultAdapter(this)
         setupActivityLaunchers()
         setupClickListeners()
 
@@ -166,6 +178,26 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         checkPermissions()
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        // Handle NFC intents and pass to active dialogs
+        if (NfcAdapter.ACTION_TAG_DISCOVERED == intent.action ||
+            NfcAdapter.ACTION_NDEF_DISCOVERED == intent.action ||
+            NfcAdapter.ACTION_TECH_DISCOVERED == intent.action
+        ) {
+            val tag: Tag? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(NfcAdapter.EXTRA_TAG, Tag::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                intent.getParcelableExtra(NfcAdapter.EXTRA_TAG)
+            }
+            tag?.let {
+                activeNfcWriteDialog?.handleTagDiscovered(it)
+                activeNfcConfigDialog?.handleTagDiscovered(it)
+            }
+        }
     }
 
     private fun setupActivityLaunchers() {
@@ -245,6 +277,18 @@ class MainActivity : AppCompatActivity() {
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { _ ->
                 sendRefreshRequest(AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE)
             }
+
+        selectNfcLockAppsLauncher =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                if (result.resultCode == RESULT_OK) {
+                    val selectedApps = result.data?.getStringArrayListExtra("SELECTED_APPS")
+                    selectedApps?.let {
+                        savedPreferencesLoader.saveNfcLockSelectedApps(selectedApps)
+                        sendRefreshRequest(AppBlockerService.INTENT_ACTION_REFRESH_NFC_LOCK_MODE)
+                    }
+                }
+            }
+
         // Register the directory picker
         directoryPicker = ZipUtils.registerDirectoryPicker(this) { directoryUri ->
             // Create the zip file in the selected directory
@@ -365,6 +409,40 @@ class MainActivity : AppCompatActivity() {
             addAutoFocusHoursActivity.launch(intent, options)
         }
 
+        // NFC Lock Mode click listeners
+        binding.selectNfcLockApps.setOnClickListener {
+            val intent = Intent(this, SelectAppsActivity::class.java)
+            intent.putStringArrayListExtra(
+                "PRE_SELECTED_APPS",
+                ArrayList(savedPreferencesLoader.getNfcLockSelectedApps())
+            )
+            selectNfcLockAppsLauncher.launch(intent, options)
+        }
+
+        binding.configureNfcLock.setOnClickListener {
+            activeNfcConfigDialog = ConfigureNfcLockDialog(savedPreferencesLoader) {
+                checkPermissions()
+                activeNfcConfigDialog = null
+            }
+            activeNfcConfigDialog?.show(supportFragmentManager, "configure_nfc_lock")
+        }
+
+        binding.writeNfcTag.setOnClickListener {
+            activeNfcWriteDialog = NfcWriteTagDialog(savedPreferencesLoader) {
+                activeNfcWriteDialog = null
+            }
+            activeNfcWriteDialog?.show(supportFragmentManager, "write_nfc_tag")
+        }
+
+        binding.nfcEmergencyUnlock.setOnClickListener {
+            NfcEmergencyUnlockDialog(savedPreferencesLoader) {
+                checkPermissions()
+            }.show(supportFragmentManager, "nfc_emergency_unlock")
+        }
+
+        binding.nfcLockStatusChip.setOnClickListener {
+            makeAccessibilityInfoDialog("App Blocker", AppBlockerService::class.java)
+        }
 
         binding.startFocusMode.setOnClickListener {
 
@@ -639,6 +717,62 @@ class MainActivity : AppCompatActivity() {
                     val isFocusedModeOn = savedPreferencesLoader.getFocusModeData().isTurnedOn
                     binding.selectFocusBlockedApps.isEnabled = !isFocusedModeOn
                     binding.startFocusMode.isEnabled = !isFocusedModeOn
+                }
+
+                // NFC Lock Mode
+                val hasNfc = nfcAdapter != null
+                val nfcLockData = savedPreferencesLoader.getNfcLockModeData()
+                val isNfcLockEnabled = nfcLockData.isEnabled
+                val isNfcReady = hasNfc && isAppBlockerOn
+
+                if (!hasNfc) {
+                    // No NFC hardware
+                    updateChip(false, binding.nfcLockStatusChip, binding.nfcLockWarning)
+                    binding.nfcLockWarning.text = getString(R.string.warning_nfc_not_available)
+                    binding.apply {
+                        selectNfcLockApps.isEnabled = false
+                        configureNfcLock.isEnabled = false
+                        writeNfcTag.isEnabled = false
+                        nfcEmergencyUnlock.visibility = View.GONE
+                    }
+                } else if (!isAppBlockerOn) {
+                    // NFC available but App Blocker service not enabled
+                    updateChip(false, binding.nfcLockStatusChip, binding.nfcLockWarning)
+                    binding.nfcLockWarning.text = getString(R.string.warning_nfc_lock_settings)
+                    binding.apply {
+                        selectNfcLockApps.isEnabled = false
+                        configureNfcLock.isEnabled = false
+                        writeNfcTag.isEnabled = false
+                        nfcEmergencyUnlock.visibility = View.GONE
+                    }
+                } else {
+                    // NFC available and App Blocker enabled
+                    binding.nfcLockWarning.visibility = View.GONE
+
+                    // Update chip status based on lock state
+                    if (isNfcLockEnabled) {
+                        binding.nfcLockStatusChip.text = getString(R.string.nfc_lock_enabled)
+                        binding.nfcLockStatusChip.chipIcon = null
+                    } else {
+                        binding.nfcLockStatusChip.text = getString(R.string.nfc_lock_disabled)
+                        binding.nfcLockStatusChip.chipIcon = null
+                    }
+
+                    // Enable/disable buttons based on lock state
+                    binding.apply {
+                        selectNfcLockApps.isEnabled = !isNfcLockEnabled
+                        configureNfcLock.isEnabled = !isNfcLockEnabled
+                        writeNfcTag.isEnabled = true
+                        nfcEmergencyUnlock.visibility = if (isNfcLockEnabled) View.VISIBLE else View.GONE
+                    }
+
+                    // Disable NFC lock settings when anti-uninstall is active
+                    if (doesAntiUninstallBlockView && isAntiUninstallOn) {
+                        binding.apply {
+                            selectNfcLockApps.isEnabled = false
+                            configureNfcLock.isEnabled = false
+                        }
+                    }
                 }
 
                 if(isGeneralSettingsOn){

--- a/app/src/main/java/nethical/digipaws/ui/activity/NfcTagActivity.kt
+++ b/app/src/main/java/nethical/digipaws/ui/activity/NfcTagActivity.kt
@@ -1,0 +1,90 @@
+package nethical.digipaws.ui.activity
+
+import android.content.Intent
+import android.nfc.NfcAdapter
+import android.nfc.Tag
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import nethical.digipaws.blockers.NfcLockBlocker
+import nethical.digipaws.services.AppBlockerService
+import nethical.digipaws.utils.SavedPreferencesLoader
+
+class NfcTagActivity : AppCompatActivity() {
+
+    private lateinit var savedPreferencesLoader: SavedPreferencesLoader
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        savedPreferencesLoader = SavedPreferencesLoader(this)
+        handleIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleIntent(intent)
+    }
+
+    private fun handleIntent(intent: Intent) {
+        if (NfcAdapter.ACTION_NDEF_DISCOVERED == intent.action) {
+            val tag: Tag? = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG)
+            val tagId = tag?.id?.let { bytesToHex(it) }
+            toggleNfcLockMode(tagId)
+        } else {
+            Toast.makeText(this, "Invalid NFC action", Toast.LENGTH_SHORT).show()
+            finish()
+        }
+    }
+
+    private fun toggleNfcLockMode(tagId: String?) {
+        val data = savedPreferencesLoader.getNfcLockModeData()
+
+        // Validate tag if required
+        if (data.requireTagValidation && tagId != null) {
+            if (!data.registeredTagIds.contains(tagId)) {
+                Toast.makeText(this, "Unregistered NFC tag", Toast.LENGTH_SHORT).show()
+                finish()
+                return
+            }
+        }
+
+        val newData: NfcLockBlocker.NfcLockModeData
+        if (data.isEnabled) {
+            // Disable NFC lock mode
+            newData = data.copy(
+                isEnabled = false,
+                enabledAt = -1,
+                autoUnlockAt = -1
+            )
+            Toast.makeText(this, "NFC Lock disabled", Toast.LENGTH_SHORT).show()
+        } else {
+            // Enable NFC lock mode
+            val autoUnlockAt = if (data.failsafeHours > 0) {
+                System.currentTimeMillis() + (data.failsafeHours * 3600000L)
+            } else {
+                -1L
+            }
+            newData = data.copy(
+                isEnabled = true,
+                enabledAt = System.currentTimeMillis(),
+                autoUnlockAt = autoUnlockAt
+            )
+            Toast.makeText(this, "NFC Lock enabled", Toast.LENGTH_SHORT).show()
+        }
+
+        savedPreferencesLoader.saveNfcLockModeData(newData)
+        sendBroadcast(Intent(AppBlockerService.INTENT_ACTION_REFRESH_NFC_LOCK_MODE))
+        finish()
+    }
+
+    private fun bytesToHex(bytes: ByteArray): String {
+        val hexArray = "0123456789ABCDEF".toCharArray()
+        val hexChars = CharArray(bytes.size * 2)
+        for (i in bytes.indices) {
+            val v = bytes[i].toInt() and 0xFF
+            hexChars[i * 2] = hexArray[v ushr 4]
+            hexChars[i * 2 + 1] = hexArray[v and 0x0F]
+        }
+        return String(hexChars)
+    }
+}

--- a/app/src/main/java/nethical/digipaws/ui/dialogs/ConfigureNfcLockDialog.kt
+++ b/app/src/main/java/nethical/digipaws/ui/dialogs/ConfigureNfcLockDialog.kt
@@ -1,0 +1,189 @@
+package nethical.digipaws.ui.dialogs
+
+import android.app.Dialog
+import android.app.PendingIntent
+import android.content.DialogInterface
+import android.content.Intent
+import android.content.IntentFilter
+import android.nfc.NfcAdapter
+import android.nfc.Tag
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import nethical.digipaws.Constants
+import nethical.digipaws.R
+import nethical.digipaws.blockers.NfcLockBlocker
+import nethical.digipaws.databinding.DialogNfcLockConfigBinding
+import nethical.digipaws.utils.SavedPreferencesLoader
+
+class ConfigureNfcLockDialog(
+    savedPreferencesLoader: SavedPreferencesLoader,
+    private val onDismissed: () -> Unit
+) : BaseDialog(savedPreferencesLoader) {
+
+    private var _binding: DialogNfcLockConfigBinding? = null
+    private val binding get() = _binding!!
+
+    private var nfcAdapter: NfcAdapter? = null
+    private var isRegisteringTag = false
+    private var registeredTagIds: HashSet<String> = hashSetOf()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        _binding = DialogNfcLockConfigBinding.inflate(layoutInflater)
+
+        val previousData = savedPreferencesLoader?.getNfcLockModeData()
+            ?: NfcLockBlocker.NfcLockModeData()
+        registeredTagIds = HashSet(previousData.registeredTagIds)
+
+        nfcAdapter = NfcAdapter.getDefaultAdapter(requireContext())
+
+        setupViews(previousData)
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setView(binding.root)
+            .setPositiveButton(getString(R.string.save)) { _, _ ->
+                saveConfiguration()
+            }
+            .setNegativeButton(getString(R.string.cancel), null)
+            .create()
+    }
+
+    private fun setupViews(data: NfcLockBlocker.NfcLockModeData) {
+        // Mode type
+        when (data.modeType) {
+            Constants.NFC_LOCK_MODE_BLOCK_SELECTED -> binding.blockSelected.isChecked = true
+            Constants.NFC_LOCK_MODE_BLOCK_ALL_EX_SELECTED -> binding.blockAll.isChecked = true
+        }
+
+        // Failsafe hours picker
+        binding.failsafeHoursPicker.minValue = 0
+        binding.failsafeHoursPicker.maxValue = 168
+        binding.failsafeHoursPicker.setValue(data.failsafeHours)
+        binding.failsafeHoursPicker.setUnit("hours")
+
+        // Emergency password
+        binding.emergencyPassword.setText(data.emergencyPassword)
+
+        // Tag validation
+        binding.requireTagValidation.isChecked = data.requireTagValidation
+        updateTagValidationViews(data.requireTagValidation)
+
+        binding.requireTagValidation.setOnCheckedChangeListener { _, isChecked ->
+            updateTagValidationViews(isChecked)
+        }
+
+        binding.btnRegisterTag.setOnClickListener {
+            startTagRegistration()
+        }
+
+        updateRegisteredTagsCount()
+    }
+
+    private fun updateTagValidationViews(isEnabled: Boolean) {
+        binding.btnRegisterTag.visibility = if (isEnabled) View.VISIBLE else View.GONE
+        binding.registeredTagsCount.visibility = if (isEnabled) View.VISIBLE else View.GONE
+    }
+
+    private fun updateRegisteredTagsCount() {
+        binding.registeredTagsCount.text =
+            getString(R.string.registered_tags, registeredTagIds.size)
+    }
+
+    private fun startTagRegistration() {
+        if (nfcAdapter == null || !nfcAdapter!!.isEnabled) {
+            Toast.makeText(requireContext(), "NFC is not available or disabled", Toast.LENGTH_SHORT)
+                .show()
+            return
+        }
+
+        isRegisteringTag = true
+        Toast.makeText(requireContext(), getString(R.string.scan_tag_to_register), Toast.LENGTH_LONG).show()
+        enableForegroundDispatch()
+    }
+
+    private fun enableForegroundDispatch() {
+        val activity = requireActivity()
+        val intent = Intent(activity, activity.javaClass).apply {
+            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            activity, 0, intent,
+            PendingIntent.FLAG_MUTABLE
+        )
+        val filters = arrayOf(IntentFilter(NfcAdapter.ACTION_TAG_DISCOVERED))
+        nfcAdapter?.enableForegroundDispatch(activity, pendingIntent, filters, null)
+    }
+
+    private fun disableForegroundDispatch() {
+        try {
+            nfcAdapter?.disableForegroundDispatch(requireActivity())
+        } catch (e: Exception) {
+            // Activity might not be in foreground
+        }
+    }
+
+    fun handleTagDiscovered(tag: Tag) {
+        if (isRegisteringTag) {
+            val tagId = bytesToHex(tag.id)
+            registeredTagIds.add(tagId)
+            updateRegisteredTagsCount()
+            Toast.makeText(requireContext(), getString(R.string.tag_registered), Toast.LENGTH_SHORT).show()
+            isRegisteringTag = false
+            disableForegroundDispatch()
+        }
+    }
+
+    private fun saveConfiguration() {
+        val modeType = when {
+            binding.blockAll.isChecked -> Constants.NFC_LOCK_MODE_BLOCK_ALL_EX_SELECTED
+            else -> Constants.NFC_LOCK_MODE_BLOCK_SELECTED
+        }
+
+        val previousData = savedPreferencesLoader?.getNfcLockModeData()
+            ?: NfcLockBlocker.NfcLockModeData()
+
+        val newData = previousData.copy(
+            modeType = modeType,
+            failsafeHours = binding.failsafeHoursPicker.getValue(),
+            emergencyPassword = binding.emergencyPassword.text.toString(),
+            requireTagValidation = binding.requireTagValidation.isChecked,
+            registeredTagIds = registeredTagIds
+        )
+
+        savedPreferencesLoader?.saveNfcLockModeData(newData)
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        onDismissed()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (isRegisteringTag) {
+            enableForegroundDispatch()
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        disableForegroundDispatch()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun bytesToHex(bytes: ByteArray): String {
+        val hexArray = "0123456789ABCDEF".toCharArray()
+        val hexChars = CharArray(bytes.size * 2)
+        for (i in bytes.indices) {
+            val v = bytes[i].toInt() and 0xFF
+            hexChars[i * 2] = hexArray[v ushr 4]
+            hexChars[i * 2 + 1] = hexArray[v and 0x0F]
+        }
+        return String(hexChars)
+    }
+}

--- a/app/src/main/java/nethical/digipaws/ui/dialogs/NfcEmergencyUnlockDialog.kt
+++ b/app/src/main/java/nethical/digipaws/ui/dialogs/NfcEmergencyUnlockDialog.kt
@@ -1,0 +1,61 @@
+package nethical.digipaws.ui.dialogs
+
+import android.app.Dialog
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import nethical.digipaws.R
+import nethical.digipaws.databinding.DialogNfcEmergencyUnlockBinding
+import nethical.digipaws.services.AppBlockerService
+import nethical.digipaws.utils.SavedPreferencesLoader
+
+class NfcEmergencyUnlockDialog(
+    savedPreferencesLoader: SavedPreferencesLoader,
+    private val onUnlocked: () -> Unit
+) : BaseDialog(savedPreferencesLoader) {
+
+    private var _binding: DialogNfcEmergencyUnlockBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        _binding = DialogNfcEmergencyUnlockBinding.inflate(layoutInflater)
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(getString(R.string.emergency_unlock_title))
+            .setView(binding.root)
+            .setPositiveButton(getString(R.string.unlock)) { _, _ ->
+                attemptUnlock()
+            }
+            .setNegativeButton(getString(R.string.cancel), null)
+            .create()
+    }
+
+    private fun attemptUnlock() {
+        val enteredPassword = binding.password.text.toString()
+        val savedData = savedPreferencesLoader?.getNfcLockModeData() ?: return
+
+        if (enteredPassword == savedData.emergencyPassword) {
+            // Disable NFC lock mode
+            val newData = savedData.copy(
+                isEnabled = false,
+                enabledAt = -1,
+                autoUnlockAt = -1
+            )
+            savedPreferencesLoader?.saveNfcLockModeData(newData)
+
+            // Send refresh broadcast
+            context?.sendBroadcast(Intent(AppBlockerService.INTENT_ACTION_REFRESH_NFC_LOCK_MODE))
+
+            Toast.makeText(requireContext(), getString(R.string.nfc_lock_unlocked), Toast.LENGTH_SHORT).show()
+            onUnlocked()
+        } else {
+            Toast.makeText(requireContext(), getString(R.string.incorrect_password), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/nethical/digipaws/ui/dialogs/NfcWriteTagDialog.kt
+++ b/app/src/main/java/nethical/digipaws/ui/dialogs/NfcWriteTagDialog.kt
@@ -1,0 +1,234 @@
+package nethical.digipaws.ui.dialogs
+
+import android.app.Dialog
+import android.app.PendingIntent
+import android.content.DialogInterface
+import android.content.Intent
+import android.content.IntentFilter
+import android.nfc.NdefMessage
+import android.nfc.NdefRecord
+import android.nfc.NfcAdapter
+import android.nfc.Tag
+import android.nfc.tech.Ndef
+import android.nfc.tech.NdefFormatable
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import nethical.digipaws.R
+import nethical.digipaws.databinding.DialogNfcWriteTagBinding
+import nethical.digipaws.utils.SavedPreferencesLoader
+
+class NfcWriteTagDialog(
+    savedPreferencesLoader: SavedPreferencesLoader,
+    private val onDismissed: () -> Unit
+) : BaseDialog(savedPreferencesLoader) {
+
+    private var _binding: DialogNfcWriteTagBinding? = null
+    private val binding get() = _binding!!
+
+    private var nfcAdapter: NfcAdapter? = null
+    private var dialog: Dialog? = null
+    private var pendingTag: Tag? = null
+
+    companion object {
+        const val NFC_URI = "digipaws://nfclock/toggle"
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        _binding = DialogNfcWriteTagBinding.inflate(layoutInflater)
+
+        nfcAdapter = NfcAdapter.getDefaultAdapter(requireContext())
+
+        if (nfcAdapter == null || !nfcAdapter!!.isEnabled) {
+            binding.description.text = "NFC is not available or disabled"
+            binding.progress.visibility = View.GONE
+        }
+
+        dialog = MaterialAlertDialogBuilder(requireContext())
+            .setView(binding.root)
+            .setNegativeButton(getString(R.string.cancel), null)
+            .create()
+
+        return dialog!!
+    }
+
+    override fun onResume() {
+        super.onResume()
+        enableForegroundDispatch()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        disableForegroundDispatch()
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        onDismissed()
+    }
+
+    private fun enableForegroundDispatch() {
+        val activity = requireActivity()
+        val intent = Intent(activity, activity.javaClass).apply {
+            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            activity, 0, intent,
+            PendingIntent.FLAG_MUTABLE
+        )
+        val filters = arrayOf(
+            IntentFilter(NfcAdapter.ACTION_TAG_DISCOVERED),
+            IntentFilter(NfcAdapter.ACTION_NDEF_DISCOVERED),
+            IntentFilter(NfcAdapter.ACTION_TECH_DISCOVERED)
+        )
+        nfcAdapter?.enableForegroundDispatch(activity, pendingIntent, filters, null)
+    }
+
+    private fun disableForegroundDispatch() {
+        try {
+            nfcAdapter?.disableForegroundDispatch(requireActivity())
+        } catch (e: Exception) {
+            // Activity might not be in foreground
+        }
+    }
+
+    fun handleTagDiscovered(tag: Tag) {
+        binding.status.text = getString(R.string.writing_tag)
+        pendingTag = tag
+
+        // Check if tag has existing data
+        val ndef = Ndef.get(tag)
+        if (ndef != null) {
+            try {
+                ndef.connect()
+                val existingMessage = ndef.ndefMessage
+                ndef.close()
+
+                if (existingMessage != null && existingMessage.records.isNotEmpty()) {
+                    // Tag has existing data - prompt user
+                    showOverwriteConfirmation(tag, existingMessage)
+                    return
+                }
+            } catch (e: Exception) {
+                // Could not read existing data, proceed with write
+            }
+        }
+
+        // No existing data or couldn't read, proceed with write
+        writeTag(tag)
+    }
+
+    private fun showOverwriteConfirmation(tag: Tag, existingMessage: NdefMessage) {
+        val existingContent = try {
+            existingMessage.records.firstOrNull()?.let { record ->
+                when {
+                    record.tnf == NdefRecord.TNF_WELL_KNOWN &&
+                    record.type.contentEquals(NdefRecord.RTD_URI) -> {
+                        val payload = record.payload
+                        if (payload.isNotEmpty()) {
+                            val prefixCode = payload[0].toInt()
+                            val uriPrefix = getUriPrefix(prefixCode)
+                            uriPrefix + String(payload, 1, payload.size - 1, Charsets.UTF_8)
+                        } else "Unknown"
+                    }
+                    record.tnf == NdefRecord.TNF_WELL_KNOWN &&
+                    record.type.contentEquals(NdefRecord.RTD_TEXT) -> {
+                        val payload = record.payload
+                        val languageCodeLength = payload[0].toInt() and 0x3F
+                        String(payload, 1 + languageCodeLength, payload.size - 1 - languageCodeLength, Charsets.UTF_8)
+                    }
+                    else -> "Binary data (${existingMessage.byteArrayLength} bytes)"
+                }
+            } ?: "Unknown data"
+        } catch (e: Exception) {
+            "Could not read existing data"
+        }
+
+        binding.progress.visibility = View.GONE
+        binding.status.text = "Tag contains existing data"
+
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle("Overwrite Tag?")
+            .setMessage("This tag already contains data:\n\n$existingContent\n\nDo you want to overwrite it with the DigiPaws NFC Lock toggle?")
+            .setPositiveButton("Overwrite") { _, _ ->
+                binding.progress.visibility = View.VISIBLE
+                binding.status.text = getString(R.string.writing_tag)
+                writeTag(tag)
+            }
+            .setNegativeButton(getString(R.string.cancel)) { _, _ ->
+                binding.progress.visibility = View.VISIBLE
+                binding.status.text = "Waiting for NFC tag..."
+            }
+            .show()
+    }
+
+    private fun getUriPrefix(code: Int): String {
+        return when (code) {
+            0x00 -> ""
+            0x01 -> "http://www."
+            0x02 -> "https://www."
+            0x03 -> "http://"
+            0x04 -> "https://"
+            0x05 -> "tel:"
+            0x06 -> "mailto:"
+            else -> ""
+        }
+    }
+
+    private fun writeTag(tag: Tag) {
+        try {
+            val record = NdefRecord.createUri(NFC_URI)
+            val message = NdefMessage(arrayOf(record))
+
+            val ndef = Ndef.get(tag)
+            if (ndef != null) {
+                ndef.connect()
+                if (!ndef.isWritable) {
+                    showError("Tag is read-only and cannot be written")
+                    ndef.close()
+                    return
+                }
+                if (ndef.maxSize < message.toByteArray().size) {
+                    showError("Tag storage is too small (${ndef.maxSize} bytes available, ${message.toByteArray().size} needed)")
+                    ndef.close()
+                    return
+                }
+                ndef.writeNdefMessage(message)
+                ndef.close()
+                onWriteSuccess()
+            } else {
+                // Try to format the tag
+                val ndefFormatable = NdefFormatable.get(tag)
+                if (ndefFormatable != null) {
+                    ndefFormatable.connect()
+                    ndefFormatable.format(message)
+                    ndefFormatable.close()
+                    onWriteSuccess()
+                } else {
+                    showError("Tag does not support NDEF format")
+                }
+            }
+        } catch (e: Exception) {
+            showError("Write failed: ${e.message}")
+        }
+    }
+
+    private fun showError(message: String) {
+        binding.progress.visibility = View.GONE
+        binding.status.text = message
+        Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show()
+    }
+
+    private fun onWriteSuccess() {
+        binding.progress.visibility = View.GONE
+        binding.status.text = getString(R.string.tag_written_success)
+        Toast.makeText(requireContext(), getString(R.string.tag_written_success), Toast.LENGTH_SHORT).show()
+        dialog?.dismiss()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/nethical/digipaws/utils/SavedPreferencesLoader.kt
+++ b/app/src/main/java/nethical/digipaws/utils/SavedPreferencesLoader.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import nethical.digipaws.blockers.FocusModeBlocker
+import nethical.digipaws.blockers.NfcLockBlocker
 import nethical.digipaws.services.UsageTrackingService.AttentionSpanVideoItem
 import nethical.digipaws.ui.activity.AppUsageConfig
 import nethical.digipaws.ui.activity.MainActivity
@@ -345,5 +346,57 @@ class SavedPreferencesLoader(private val context: Context) {
         val sharedPreferences =
             context.getSharedPreferences("grayscale", Context.MODE_PRIVATE)
         sharedPreferences.edit().putStringSet("apps", apps).apply()
+    }
+
+    fun saveNfcLockModeData(nfcLockModeData: NfcLockBlocker.NfcLockModeData) {
+        val sharedPreferences =
+            context.getSharedPreferences("nfc_lock_mode", Context.MODE_PRIVATE)
+        val editor = sharedPreferences.edit()
+        val gson = Gson()
+
+        val json = gson.toJson(nfcLockModeData)
+
+        editor.putString("nfc_lock_mode_data", json)
+        editor.apply()
+    }
+
+    fun getNfcLockModeData(): NfcLockBlocker.NfcLockModeData {
+        val sharedPreferences =
+            context.getSharedPreferences("nfc_lock_mode", Context.MODE_PRIVATE)
+        val gson = Gson()
+
+        val json = sharedPreferences.getString("nfc_lock_mode_data", null)
+
+        if (json.isNullOrEmpty()) return NfcLockBlocker.NfcLockModeData()
+
+        val type =
+            object : TypeToken<NfcLockBlocker.NfcLockModeData>() {}.type
+        return gson.fromJson(json, type)
+    }
+
+    fun saveNfcLockSelectedApps(appList: List<String>) {
+        val sharedPreferences =
+            context.getSharedPreferences("nfc_lock_mode", Context.MODE_PRIVATE)
+        val editor = sharedPreferences.edit()
+        val gson = Gson()
+
+        val json = gson.toJson(appList)
+
+        editor.putString("selected_apps", json)
+        editor.apply()
+    }
+
+    fun getNfcLockSelectedApps(): List<String> {
+        val sharedPreferences =
+            context.getSharedPreferences("nfc_lock_mode", Context.MODE_PRIVATE)
+        val gson = Gson()
+
+        val json = sharedPreferences.getString("selected_apps", null)
+
+        if (json.isNullOrEmpty()) return listOf()
+
+        val type =
+            object : TypeToken<List<String>>() {}.type
+        return gson.fromJson(json, type)
     }
 }

--- a/app/src/main/res/drawable/baseline_nfc_24.xml
+++ b/app/src/main/res/drawable/baseline_nfc_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20,2L4,2c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM20,20L4,20L4,4h16v16zM18,6h-5c-1.1,0 -2,0.9 -2,2v2.28c-0.6,0.35 -1,0.98 -1,1.72 0,1.1 0.9,2 2,2s2,-0.9 2,-2c0,-0.74 -0.4,-1.38 -1,-1.72L13,8h5v8h-4v2h4c1.1,0 2,-0.9 2,-2L20,8c0,-1.1 -0.9,-2 -2,-2zM12,14c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1 1,0.45 1,1 -0.45,1 -1,1zM6,12v4c0,1.1 0.9,2 2,2h3v-2L8,16v-4L6,12z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -167,6 +167,95 @@
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.card.MaterialCardView
+            android:id="@+id/nfc_lock_card"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="16dp"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="4dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        style="@style/TextAppearance.Material3.TitleLarge"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:text="@string/nfc_lock_mode"
+                        android:textStyle="bold"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/nfc_lock_status_chip"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintWidth_default="spread" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/nfc_lock_status_chip"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/nfc_lock_disabled"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <Button
+                    android:id="@+id/select_nfc_lock_apps"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:enabled="false"
+                    android:text="@string/select_apps" />
+
+                <Button
+                    android:id="@+id/configure_nfc_lock"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:enabled="false"
+                    android:text="@string/configure_nfc_lock" />
+
+                <Button
+                    android:id="@+id/write_nfc_tag"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:enabled="false"
+                    android:text="@string/write_nfc_tag" />
+
+                <Button
+                    android:id="@+id/nfc_emergency_unlock"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:visibility="gone"
+                    android:text="@string/emergency_unlock" />
+
+                <TextView
+                    android:id="@+id/nfc_lock_warning"
+                    style="@style/TextAppearance.Material3.BodySmall"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/warning_nfc_lock_settings"
+                    android:textAlignment="center"
+                    android:textColor="?attr/colorError" />
+
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
             android:id="@+id/monochrome_card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_nfc_emergency_unlock.xml
+++ b/app/src/main/res/layout/dialog_nfc_emergency_unlock.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/emergency_unlock_desc" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/password_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:hint="@string/password"
+        app:endIconMode="password_toggle">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/password"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_nfc_lock_config.xml
+++ b/app/src/main/res/layout/dialog_nfc_lock_config.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            style="@style/TextAppearance.Material3.TitleLarge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:text="@string/configure_nfc_lock_mode"
+            android:textSize="24sp"
+            android:textStyle="bold" />
+
+        <RadioGroup
+            android:id="@+id/mode_type"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp">
+
+            <TextView
+                style="@style/TextAppearance.Material3.BodySmall"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                android:text="Select blocking mode" />
+
+            <RadioButton
+                android:id="@+id/block_all"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/block_all_except_selected" />
+
+            <RadioButton
+                android:id="@+id/block_selected"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/block_only_selected" />
+        </RadioGroup>
+
+        <TextView
+            style="@style/TextAppearance.Material3.BodySmall"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:padding="8dp"
+            android:text="@string/failsafe_hours_desc" />
+
+        <nethical.digipaws.views.HorizontalNumberPicker
+            android:id="@+id/failsafe_hours_picker"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/password_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:hint="@string/emergency_password"
+            app:helperText="@string/emergency_password_desc">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/emergency_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textPassword" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/require_tag_validation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/require_tag_validation" />
+
+        <TextView
+            style="@style/TextAppearance.Material3.BodySmall"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:text="@string/require_tag_validation_desc"
+            android:textColor="?android:textColorSecondary" />
+
+        <Button
+            android:id="@+id/btn_register_tag"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/register_tag"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/registered_tags_count"
+            style="@style/TextAppearance.Material3.BodySmall"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:visibility="gone" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="8dp"
+            android:background="?android:attr/listDivider" />
+
+        <TextView
+            style="@style/TextAppearance.Material3.BodySmall"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:text="@string/nfc_uri_info_title" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            app:cardBackgroundColor="?attr/colorSurfaceVariant"
+            app:cardCornerRadius="8dp"
+            app:cardElevation="0dp">
+
+            <TextView
+                android:id="@+id/nfc_uri_text"
+                style="@style/TextAppearance.Material3.BodyMedium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="monospace"
+                android:padding="12dp"
+                android:text="digipaws://nfclock/toggle"
+                android:textIsSelectable="true" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <TextView
+            style="@style/TextAppearance.Material3.BodySmall"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:text="@string/nfc_uri_info_desc"
+            android:textColor="?android:textColorSecondary" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/dialog_nfc_write_tag.xml
+++ b/app/src/main/res/layout/dialog_nfc_write_tag.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:gravity="center">
+
+    <ImageView
+        android:id="@+id/nfc_icon"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:src="@drawable/baseline_nfc_24"
+        android:contentDescription="NFC" />
+
+    <TextView
+        android:id="@+id/title"
+        style="@style/TextAppearance.Material3.TitleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/write_nfc_tag_title"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/description"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:gravity="center"
+        android:text="@string/write_nfc_tag_desc" />
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:indeterminate="true" />
+
+    <TextView
+        android:id="@+id/status"
+        style="@style/TextAppearance.Material3.BodySmall"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textColor="?android:textColorSecondary" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,4 +177,40 @@
     <string name="guide">Guide</string>
     <string name="go_back">Go back</string>
     <string name="block_making_changes_to_blockers_during_this_period">Block making changes to blockers during this period.</string>
+
+    <!-- NFC Lock Mode -->
+    <string name="nfc_lock_mode">NFC Lock Mode</string>
+    <string name="nfc_lock_mode_desc">Lock/unlock apps by scanning an NFC tag</string>
+    <string name="configure_nfc_lock">Configure</string>
+    <string name="write_nfc_tag">Write NFC Tag</string>
+    <string name="emergency_unlock">Emergency Unlock</string>
+    <string name="warning_nfc_lock_settings">Enable App Blocker Accessibility Service to use NFC Lock Mode</string>
+    <string name="warning_nfc_not_available">NFC is not available on this device</string>
+    <string name="nfc_lock_enabled">Locked</string>
+    <string name="nfc_lock_disabled">Unlocked</string>
+    <string name="configure_nfc_lock_mode">Configure NFC Lock Mode</string>
+    <string name="failsafe_hours">Failsafe Timer (hours)</string>
+    <string name="failsafe_hours_desc">Auto-unlock after this many hours (0 = disabled)</string>
+    <string name="emergency_password">Emergency Password</string>
+    <string name="emergency_password_desc">Password to unlock without NFC tag</string>
+    <string name="require_tag_validation">Require Tag Validation</string>
+    <string name="require_tag_validation_desc">Only allow registered NFC tags</string>
+    <string name="register_tag">Register Tag</string>
+    <string name="registered_tags">Registered Tags: %1$d</string>
+    <string name="write_nfc_tag_title">Write NFC Tag</string>
+    <string name="write_nfc_tag_desc">Hold an NFC tag near your device to write the DigiPaws toggle command.</string>
+    <string name="writing_tag">Writing to tag...</string>
+    <string name="tag_written_success">Tag written successfully</string>
+    <string name="tag_write_failed">Failed to write tag</string>
+    <string name="emergency_unlock_title">Emergency Unlock</string>
+    <string name="emergency_unlock_desc">Enter your emergency password to unlock NFC Lock Mode</string>
+    <string name="unlock">Unlock</string>
+    <string name="incorrect_password">Incorrect password</string>
+    <string name="nfc_lock_unlocked">NFC Lock Mode unlocked</string>
+    <string name="scan_tag_to_register">Scan an NFC tag to register it</string>
+    <string name="tag_registered">Tag registered successfully</string>
+    <string name="block_all_except_selected">Block all apps except selected</string>
+    <string name="block_only_selected">Block only selected apps</string>
+    <string name="nfc_uri_info_title">Manual NFC Tag Setup</string>
+    <string name="nfc_uri_info_desc">You can use an external NFC writing app (like NFC Tools) to write this URI to your tag. The tag will then work with DigiPaws NFC Lock Mode.</string>
 </resources>

--- a/app/src/test/java/nethical/digipaws/NfcLockBlockerTest.kt
+++ b/app/src/test/java/nethical/digipaws/NfcLockBlockerTest.kt
@@ -1,0 +1,158 @@
+package nethical.digipaws
+
+import nethical.digipaws.blockers.NfcLockBlocker
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class NfcLockBlockerTest {
+
+    private lateinit var blocker: NfcLockBlocker
+
+    @Before
+    fun setUp() {
+        blocker = NfcLockBlocker()
+    }
+
+    @Test
+    fun testDisabledMode_blocksNothing() {
+        blocker.nfcLockModeData = NfcLockBlocker.NfcLockModeData(
+            isEnabled = false,
+            modeType = Constants.NFC_LOCK_MODE_BLOCK_SELECTED
+        )
+        blocker.selectedApps = hashSetOf("com.example.blocked")
+
+        val result = blocker.doesAppNeedToBeBlocked("com.example.blocked")
+
+        assertFalse(result.isBlocked)
+        assertFalse(result.isRequestingToUpdateSPData)
+    }
+
+    @Test
+    fun testBlockSelectedMode_blocksSelectedApp() {
+        blocker.nfcLockModeData = NfcLockBlocker.NfcLockModeData(
+            isEnabled = true,
+            modeType = Constants.NFC_LOCK_MODE_BLOCK_SELECTED
+        )
+        blocker.selectedApps = hashSetOf("com.example.blocked", "com.example.blocked2")
+
+        val result = blocker.doesAppNeedToBeBlocked("com.example.blocked")
+
+        assertTrue(result.isBlocked)
+    }
+
+    @Test
+    fun testBlockSelectedMode_allowsUnselectedApp() {
+        blocker.nfcLockModeData = NfcLockBlocker.NfcLockModeData(
+            isEnabled = true,
+            modeType = Constants.NFC_LOCK_MODE_BLOCK_SELECTED
+        )
+        blocker.selectedApps = hashSetOf("com.example.blocked")
+
+        val result = blocker.doesAppNeedToBeBlocked("com.example.allowed")
+
+        assertFalse(result.isBlocked)
+    }
+
+    @Test
+    fun testBlockAllExceptMode_blocksUnselectedApp() {
+        blocker.nfcLockModeData = NfcLockBlocker.NfcLockModeData(
+            isEnabled = true,
+            modeType = Constants.NFC_LOCK_MODE_BLOCK_ALL_EX_SELECTED
+        )
+        blocker.selectedApps = hashSetOf("com.example.allowed")
+
+        val result = blocker.doesAppNeedToBeBlocked("com.example.blocked")
+
+        assertTrue(result.isBlocked)
+    }
+
+    @Test
+    fun testBlockAllExceptMode_allowsSelectedApp() {
+        blocker.nfcLockModeData = NfcLockBlocker.NfcLockModeData(
+            isEnabled = true,
+            modeType = Constants.NFC_LOCK_MODE_BLOCK_ALL_EX_SELECTED
+        )
+        blocker.selectedApps = hashSetOf("com.example.allowed")
+
+        val result = blocker.doesAppNeedToBeBlocked("com.example.allowed")
+
+        assertFalse(result.isBlocked)
+    }
+
+    @Test
+    fun testFailsafe_autoDisablesWhenExpired() {
+        val pastTime = System.currentTimeMillis() - 1000 // 1 second in the past
+        blocker.nfcLockModeData = NfcLockBlocker.NfcLockModeData(
+            isEnabled = true,
+            modeType = Constants.NFC_LOCK_MODE_BLOCK_SELECTED,
+            autoUnlockAt = pastTime
+        )
+        blocker.selectedApps = hashSetOf("com.example.blocked")
+
+        val result = blocker.doesAppNeedToBeBlocked("com.example.blocked")
+
+        assertFalse(result.isBlocked)
+        assertTrue(result.isRequestingToUpdateSPData)
+        assertFalse(blocker.nfcLockModeData.isEnabled)
+    }
+
+    @Test
+    fun testFailsafeDisabled_neverAutoDisables() {
+        blocker.nfcLockModeData = NfcLockBlocker.NfcLockModeData(
+            isEnabled = true,
+            modeType = Constants.NFC_LOCK_MODE_BLOCK_SELECTED,
+            autoUnlockAt = -1 // Failsafe disabled
+        )
+        blocker.selectedApps = hashSetOf("com.example.blocked")
+
+        val result = blocker.doesAppNeedToBeBlocked("com.example.blocked")
+
+        assertTrue(result.isBlocked)
+        assertFalse(result.isRequestingToUpdateSPData)
+        assertTrue(blocker.nfcLockModeData.isEnabled)
+    }
+
+    @Test
+    fun testFailsafe_stillActiveBeforeExpiry() {
+        val futureTime = System.currentTimeMillis() + 3600000 // 1 hour in the future
+        blocker.nfcLockModeData = NfcLockBlocker.NfcLockModeData(
+            isEnabled = true,
+            modeType = Constants.NFC_LOCK_MODE_BLOCK_SELECTED,
+            autoUnlockAt = futureTime
+        )
+        blocker.selectedApps = hashSetOf("com.example.blocked")
+
+        val result = blocker.doesAppNeedToBeBlocked("com.example.blocked")
+
+        assertTrue(result.isBlocked)
+        assertEquals(futureTime, result.autoUnlockAt)
+        assertFalse(result.isRequestingToUpdateSPData)
+    }
+
+    @Test
+    fun testEmptySelectedApps_blockSelectedMode_blocksNothing() {
+        blocker.nfcLockModeData = NfcLockBlocker.NfcLockModeData(
+            isEnabled = true,
+            modeType = Constants.NFC_LOCK_MODE_BLOCK_SELECTED
+        )
+        blocker.selectedApps = hashSetOf()
+
+        val result = blocker.doesAppNeedToBeBlocked("com.example.app")
+
+        assertFalse(result.isBlocked)
+    }
+
+    @Test
+    fun testEmptySelectedApps_blockAllExceptMode_blocksAll() {
+        blocker.nfcLockModeData = NfcLockBlocker.NfcLockModeData(
+            isEnabled = true,
+            modeType = Constants.NFC_LOCK_MODE_BLOCK_ALL_EX_SELECTED
+        )
+        blocker.selectedApps = hashSetOf()
+
+        val result = blocker.doesAppNeedToBeBlocked("com.example.app")
+
+        assertTrue(result.isBlocked)
+    }
+}


### PR DESCRIPTION
Implemented as another block set, toggled by an NFC tag which can be written by the app. Has an emergency unlock feature + an optional timer instead of only using the tag to unlock the apps.

Full disclosure: I have no idea what I'm doing with respect to Android development, and this was mostly Claude generated code. However I couldn't find a FOSS app blocker with support for NFC tags on android (though there were a few for apple devices), and since [other people](https://www.unpluq.com/) seem to want $100 AND a subscription for this, I figured I could just try adding this to digipaws. I've tested it on my phone (pixel 9) and it seems to work well, but if you don't want to deal with the bloat/potential bugs that this may introduce, feel free to close this PR! Maybe it could serve as inspiration for people who know what they're doing :) 