### PR TITLE
Support for MyInsta in reels stat tracking

### DIFF
--- a/app/src/main/java/nethical/digipaws/blockers/ViewBlocker.kt
+++ b/app/src/main/java/nethical/digipaws/blockers/ViewBlocker.kt
@@ -27,6 +27,7 @@ class ViewBlocker : BaseBlocker() {
         )
         val BLOCKED_VIEW_ID_LIST = mutableListOf(
             "com.instagram.android:id/root_clips_layout",
+            "com.myinsta.android:id/root_clips_layout",
             "com.google.android.youtube:id/reel_recycler",
             "app.revanced.android.youtube:id/reel_recycler"
         )

--- a/app/src/main/java/nethical/digipaws/services/UsageTrackingService.kt
+++ b/app/src/main/java/nethical/digipaws/services/UsageTrackingService.kt
@@ -65,7 +65,8 @@ class UsageTrackingService : BaseBlockingService() {
             "com.google.android.youtube" to 2,
             "app.revanced.android.youtube" to 2,
             "com.facebook.katana" to 2,
-            "com.instagram.android" to 2
+            "com.instagram.android" to 2,
+            "com.myinsta.android" to 2
 
         )
 
@@ -75,6 +76,7 @@ class UsageTrackingService : BaseBlockingService() {
             "com.ss.android.ugc.aweme",
 
             "com.instagram.android",
+            "com.myinsta.android",
             "com.google.android.youtube",
             "app.revanced.android.youtube",
             "com.facebook.katana"
@@ -304,6 +306,17 @@ class UsageTrackingService : BaseBlockingService() {
                             "com.instagram.android:id/root_clips_layout"
                         )
                         if (reelView != null) handleScrollEvent("com.instagram.android") 
+                        else hideReelTrackingView()
+                    }
+
+                    // handle MyInsta scrolls
+                    event.source?.className == "androidx.viewpager.widget.ViewPager" && 
+                    event.packageName == "com.myinsta.android" -> {
+                        val reelView = ViewBlocker.findElementById(
+                            rootInActiveWindow,
+                            "com.myinsta.android:id/root_clips_layout"
+                        )
+                        if (reelView != null) handleScrollEvent("com.myinsta.android") 
                         else hideReelTrackingView()
                     }
 


### PR DESCRIPTION
Hello,

I've added support for MyInsta in the reels count usage tracking. It was fairly simple given there seem to be a few different variants digipaws support.

MyInsta is a mod of instagram that allows you to download reels and a few other features, remove parts of the app etc. They have a re-packaged app (they call a clone) that lets you install without root. I think this is the official website but I'm not 100% https://myinsta.app/faq

The package name is com.myinsta.android

It was mostly me coaching claude sonnet 4.6 and I don't frequent in android much but I've installed, uninstalled and re-installed the app a few times manually without AI and it's working as it does with regular Instagram.

Attached is a screenshot of it working but it just looks like regular Instagram.

Let me know if you have any questions.

Thank you for the app use it all the time (mostly in anger, I'm addicted)

![Screenshot_2026-02-22-00-07-05-58_bb1d8d43f9cd7d9cd282e43472a57fa7](https://github.com/user-attachments/assets/7ed0463a-7ba4-4486-8e06-555a6f2f935d)
