### PR TITLE
fix reel count cap not resetting on new device day

### DIFF
--- a/app/src/main/java/neth/iecal/curbox/blockers/ReelBlocker.kt
+++ b/app/src/main/java/neth/iecal/curbox/blockers/ReelBlocker.kt
@@ -65,6 +65,7 @@ class ReelBlocker : BaseBlocker() {
     private var timeBAsedConfig : ReelTimeConfig? = null
     private var countBasedConfig : ReelCountConfig? = null
     private var currentDailyCount: Int = 0
+    private var currentCountDate: String? = null
     private var settingsJob: Job? = null
     private var countJob: Job? = null
     
@@ -144,6 +145,7 @@ class ReelBlocker : BaseBlocker() {
                 }
                 ReelBlockingType.USAGE -> TODO()
                 ReelBlockingType.REEL_COUNT -> {
+                    ensureCountFlowForToday()
                     val limit = getDailyReelCountLimit()
                     if (limit != null && limit > 0 && currentDailyCount >= limit) {
                         showWarningScreen(viewId)
@@ -192,9 +194,28 @@ class ReelBlocker : BaseBlocker() {
             }
         }
 
+        launchCountFlow(TimeTools.getCurrentDate())
+    }
+
+    /**
+     * Re-subscribes currentDailyCount to today's row. Room's flow only emits when the
+     * queried row changes, so a subscription bound to yesterday's date never sees today's
+     * writes — without this, yesterday's cap keeps blocking after midnight.
+     */
+    private fun ensureCountFlowForToday() {
+        val today = TimeTools.getCurrentDate()
+        if (today != currentCountDate) {
+            currentDailyCount = 0
+            launchCountFlow(today)
+        }
+    }
+
+    private fun launchCountFlow(date: String) {
+        countJob?.cancel()
+        currentCountDate = date
         val db = AppDatabase.getInstance(service)
         countJob = CoroutineScope(Dispatchers.IO).launch {
-            db.reelStatsDao().getCountFlow(TimeTools.getCurrentDate()).collectLatest { count ->
+            db.reelStatsDao().getCountFlow(date).collectLatest { count ->
                 currentDailyCount = count ?: 0
             }
         }


### PR DESCRIPTION
 ## Summary                                                                                   
  - Fixes the issue where reel-count blocker continuing to block on a new device day after the previous day's cap was reached.                                                                       
- `ReelBlocker.setupBlocker()` was subscribing `currentDailyCount` via `reelStatsDao.getCountFlow(TimeTools.getCurrentDate())` where `getCurrentDate()` was evaluated once at service start. Room's flow only emits when the queried row changes, so the subscription stayed bound to yesterday's row forever. `ReelsCountTracker.onReelCounted()` correctly writes to a new row for today, but that row was never observed.                    
- Extracted the subscription into `launchCountFlow(date)` and added `ensureCountFlowForToday()`, called from the `REEL_COUNT` branch of `doViewBlockerCheck`. When the device day has rolled over, the stale job is cancelled, `currentDailyCount` is reset to 0, and the flow is re-subscribed to today's row. Accessibility events fire frequently enough that the first event after midnight repairs the subscription; `TIMED` users pay no extra cost.                                                                              
             
  ## Test plan
  - [x] Set a low REEL_COUNT cap (e.g. 5), scroll past it, confirm the warning screen appears.
  - [x] Advance the device clock past midnight (or wait) without restarting the accessibility service.                                                                                     
  - [x] Open a reel-containing app: verify reels are no longer blocked and `currentDailyCount` starts from 0.                                                                              
  - [x] Scroll past today's cap: verify blocking resumes for the new day.                     
  - [ ] Confirm `TIMED` and `USAGE` modes are unaffected.